### PR TITLE
Remove the protocol infrastructure properties. These is detail from

### DIFF
--- a/draft-fossaceca-dult-finding.md
+++ b/draft-fossaceca-dult-finding.md
@@ -493,7 +493,7 @@ can change. This rate limiting works as follows:
 
 1. During the setup/pairing phase, the accessory and owning
    device interact with the central service, which
-   signs each temporal key using a blind signature scheme.
+   signs each temporal key using a blind signature scheme
    The owning device stores the signatures for each key `Y_i`.
 
 1. When it wishes to retrieve the location for a given accessory
@@ -512,7 +512,6 @@ but an attacker who purchases N devices can then use N times
 that many keys per window, potentially coordinating usage across
 spatially separated devices to reduce the per-device cost.
 [[OPEN ISSUE: Can we do better than this?]]
-
 
 
 # Protocol Definition
@@ -551,6 +550,7 @@ Owner Device `OD` queries the Crowdsourced Network `CN` for the encrypted locati
 ## Partial Blind Signature Scheme
 
 [[OPEN ISSUE: Which blind signature scheme to use.]]
+
 In order to verify the parties involved in the protocol, we rely on a
 partially blind signature scheme. {{?RFC9474}} describes a blind signature
 scheme as follows:
@@ -684,7 +684,6 @@ the hash of the current public key and the current time.
 [[OPEN ISSUE: Should we work in terms of hashes or the public
 keys. What we send has to be what's looked up.]]. `CN` stores the resulting
 values indexed under the hash of the public key.
-
 
 
 

--- a/draft-fossaceca-dult-finding.md
+++ b/draft-fossaceca-dult-finding.md
@@ -548,30 +548,6 @@ Finder Device `FD` receives a Bluetooth packet, and uploads a location report to
 Owner Device `OD` queries the Crowdsourced Network `CN` for the encrypted location report.
 
 
-## General Protocol Infrastructure Properties
-
-We define the following constraints, adapted from {{BlindMy}} Section 4.2.
-
-- There exists an agreed upon elliptic curve group with a generator,
-a secure Message Authentication Algorithm, and a hashing
-function *H*.
-
-- `CN` knows a key pair `(K`<sub>S</sub>,`P`<sub>S</sub>`)`, where the public key
-`P`<sub>S</sub> is known to all participants.
-
-- `CN` has a private symmetric encryption key K<sub>SERIAL</sub>.
-
-- `CN` maintains a database of registered serial values D<sub>SERIAL</sub>
-[[OPEN ISSUE: Does this create a privacy concern? ]]
-
--  Each Accessory `ACC`<sub>i</sub> is provisioned with a unique
-   serial number and tag (`Serial`<sub>i</sub>, `T`<sub>i</sub>),
-   where the tag is a MAC computed over D<sub>SERIAL</sub>.
-
-- All parties have a synchronized clock and the ability to represent the current day (or another arbitrary timestamp) as an integer
-
-- A parameter *N* is defined by the protocol that represents the number of encryption keys produced during the pairing algorithm.
-
 ## Partial Blind Signature Scheme
 
 [[OPEN ISSUE: Which blind signature scheme to use.]]

--- a/draft-fossaceca-dult-finding.md
+++ b/draft-fossaceca-dult-finding.md
@@ -493,7 +493,7 @@ can change. This rate limiting works as follows:
 
 1. During the setup/pairing phase, the accessory and owning
    device interact with the central service, which
-   signs each temporal key using a blind signature scheme
+   signs each temporal key using a blind signature scheme.
    The owning device stores the signatures for each key `Y_i`.
 
 1. When it wishes to retrieve the location for a given accessory


### PR DESCRIPTION
BlindMy that isn't relevant in the protocol sketch we supply here. Specifically:

- We just talk about blind signatures generically so we don't need to discuss the group
- We assume that there is some mechanism for `CN` to authenticate the tag, but maybe not the specific one in BlindMy